### PR TITLE
Support für user locale

### DIFF
--- a/src/Stringintelligenz.php
+++ b/src/Stringintelligenz.php
@@ -96,7 +96,7 @@ class Stringintelligenz {
 		) );
 
 		// Only for de_DE (informal) for now.
-		if ( 'de_DE' !== get_locale() ) {
+		if ( 'de_DE' !== $this->get_locale() ) {
 			add_action( 'admin_notices', array( new StringintelligenzAdminNotice(
 				$this->templates_folder . '/admin-notice-locale-not-supported.php'
 			), 'render' ) );
@@ -134,5 +134,15 @@ class Stringintelligenz {
 			new StringintelligenzReadableTextDomainLoader()
 		);
 		add_filter( 'override_load_textdomain', array( $override, 'override' ), 10, 3 );
+	}
+
+	/**
+	 * Returns the (user) locale.
+	 *
+	 * @return string The (user) locale.
+	 */
+	private function get_locale() {
+
+		return (string) ( function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale() );
 	}
 }

--- a/stringintelligenz.php
+++ b/stringintelligenz.php
@@ -18,5 +18,18 @@ defined( 'ABSPATH' ) or die();
  */
 require_once dirname( __FILE__ ) . '/src/Stringintelligenz.php';
 
-$stringintelligenz = new Stringintelligenz( __FILE__ );
-$stringintelligenz->initialize();
+/**
+ * Initializes Stringintelligenz.
+ *
+ * @since   0.2.2
+ * @wp-hook plugins_loaded
+ *
+ * @return void
+ */
+function initialize_stringintelligenz() {
+
+	$stringintelligenz = new Stringintelligenz( __FILE__ );
+	$stringintelligenz->initialize();
+}
+
+add_action( 'plugins_loaded', 'initialize_stringintelligenz' );

--- a/templates/admin-notice-locale-not-supported.php
+++ b/templates/admin-notice-locale-not-supported.php
@@ -3,10 +3,11 @@
 	<?php
 	printf(
 		__(
-			'Switch to <strong>“Deutsch”</strong> in <a href="%s">Settings→General→Site&#160;Language</a> in order to enable gender-sensitive German in your WordPress admin interface.<br><em>(Quick check: As an administrator you should see the word “Profile” instead of “Benutzer” in your admin menu after you have activated Deutsch.)</em>',
+			'Switch to <strong>“Deutsch”</strong> at <a href="%1$s">Settings→General→Site&#160;Language</a> or at <a href="%2$s">Profile→Personal&#160;Options→Language</a> in order to enable inclusive German in your WordPress admin interface.<br><em>(Quick check: As an administrator you should see the word “Profile” instead of “Benutzer” in your admin menu after you have activated Deutsch.)</em>',
 			'stringintelligenz'
 		),
-		admin_url( 'options-general.php' )
+		admin_url( 'options-general.php' ),
+		admin_url( 'profile.php' )
 	);
 	?>
 </p>


### PR DESCRIPTION
Unterstützt die neuen user locales in WordPress 4.7.

Closes #22 when merged.